### PR TITLE
Fix pulling in allImagesAndFontsArray in storybook webpack config

### DIFF
--- a/packages/example-munchit/.storybook/webpack.config.js
+++ b/packages/example-munchit/.storybook/webpack.config.js
@@ -26,9 +26,9 @@ module.exports = (storybookBaseConfig, configType) => {
     },
     loaders.typescript,
     loaders.mjs,
-    loaders.graphql
+    loaders.graphql,
+    ...loaders.allImagesAndFontsArray
   );
-  storybookBaseConfig.module.rules.concat(loaders.allImagesAndFontsArray);
 
   storybookBaseConfig.resolve.extensions.push(".ts", ".tsx");
   storybookBaseConfig.resolve.modules.unshift(


### PR DESCRIPTION
Previously the values were concatenated without mutating `storybookBaseConfig.module.rules`, so it was basically a no-op.