### PR TITLE
count() returns a number

### DIFF
--- a/packages/records/src/index.ts
+++ b/packages/records/src/index.ts
@@ -203,7 +203,7 @@ export abstract class TableHelpers<
   }
 
   async count(): Promise<number> {
-    return await this.table().count();
+    return parseInt((await this.table().count())[0].count);
   }
 
   findById = new DataLoader<SavedR[IdKeyT], SavedR | undefined>(async ids => {


### PR DESCRIPTION
`0` instead of `[ { count: '0' } ]`